### PR TITLE
Fix Dict.Contains(key, value) for collision-chain entries

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 - [Telemetry] Fixed WallClockTime timer disposal so repeated Dispose calls do not corrupt timer state
 - [Introspection] Fixed native library loading on Windows using netstandard2.0 (https://github.com/aardvark-platform/aardvark.base/issues/86)
+- [Base] Fixed Dict.Contains(key, value) for collided entries in hash buckets
 
 ### 5.3.21
 - [Base] Simplified computation of Constant<T>.MachineEpsilon

--- a/src/Aardvark.Base/Symbol/Dict_auto.cs
+++ b/src/Aardvark.Base/Symbol/Dict_auto.cs
@@ -755,7 +755,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -779,7 +779,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -3613,7 +3613,7 @@ namespace Aardvark.Base
             while (ei > 0)
             {
                 if (m_extraArray[ei].Item.Key == hash
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -5944,7 +5944,7 @@ namespace Aardvark.Base
             while (ei > 0)
             {
                 if (m_extraArray[ei].Item.Key.Id == hash
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -8509,7 +8509,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -8533,7 +8533,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -11247,7 +11247,7 @@ namespace Aardvark.Base
             while (ei > 0)
             {
                 if (m_extraArray[ei].Item.Key == hash
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -17452,7 +17452,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -17478,7 +17478,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -20150,7 +20150,7 @@ namespace Aardvark.Base
             while (ei > 0)
             {
                 if (m_extraArray[ei].Item.Key == hash
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -22288,7 +22288,7 @@ namespace Aardvark.Base
             while (ei > 0)
             {
                 if (m_extraArray[ei].Item.Key.Id == hash
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -24674,7 +24674,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -24700,7 +24700,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -27352,7 +27352,7 @@ namespace Aardvark.Base
             while (ei > 0)
             {
                 if (m_extraArray[ei].Item.Key == hash
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -29568,7 +29568,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -29592,7 +29592,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -32592,7 +32592,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -32616,7 +32616,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -37318,7 +37318,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -37344,7 +37344,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -40196,7 +40196,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }
@@ -40222,7 +40222,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item.Hash == hash
                     && key.Equals(m_extraArray[ei].Item.Key)
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }

--- a/src/Aardvark.Base/Symbol/Dict_template.cs
+++ b/src/Aardvark.Base/Symbol/Dict_template.cs
@@ -976,7 +976,7 @@ namespace Aardvark.Base
             {
                 if (m_extraArray[ei].Item__Hash__ == hash/*# if (hasKey) { */
                     && key.Equals(m_extraArray[ei].Item__Key__)/*# } */
-                    && value.Equals(m_firstArray[fi].Item.Value))
+                    && value.Equals(m_extraArray[ei].Item.Value))
                     return true;
                 ei = m_extraArray[ei].Next;
             }

--- a/src/Tests/Aardvark.Base.Tests/AlgoDat/DictTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/AlgoDat/DictTests.cs
@@ -10,6 +10,31 @@ namespace Aardvark.Tests
     [TestFixture]
     public class DictTests : TestSuite
     {
+        private sealed class CollisionKey : IEquatable<CollisionKey>
+        {
+            public int Id { get; }
+
+            public CollisionKey(int id)
+            {
+                Id = id;
+            }
+
+            public bool Equals(CollisionKey other)
+            {
+                return other != null && Id == other.Id;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is CollisionKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return 0;
+            }
+        }
+
         public DictTests() : base() { }
         public DictTests(TestSuite.Options options) : base(options) { }
 
@@ -359,28 +384,30 @@ namespace Aardvark.Tests
         [Test]
         public void ContainsKeyValueForCollisionChainEntry()
         {
-            var dict = new Dict<int, int>();
+            var dict = new Dict<CollisionKey, string>();
+            var firstKey = new CollisionKey(1);
+            var secondKey = new CollisionKey(2);
 
-            // Dict starts with capacity 7, so 1 and 8 collide into the same bucket.
-            dict.Add(1, 10);
-            dict.Add(8, 20);
+            dict.Add(firstKey, "first");
+            dict.Add(secondKey, "second");
 
-            Assert.IsTrue(dict.Contains(1, 10));
-            Assert.IsTrue(dict.Contains(8, 20));
-            Assert.IsFalse(dict.Contains(8, 10));
+            Assert.IsTrue(dict.Contains(firstKey, "first"));
+            Assert.IsTrue(dict.Contains(secondKey, "second"));
+            Assert.IsFalse(dict.Contains(secondKey, "first"));
         }
 
         [Test]
         public void ContainsKeyValueForStackedDuplicateKeyEntry()
         {
-            var dict = new Dict<int, int>(stackDuplicateKeys: true);
+            var dict = new Dict<CollisionKey, string>(stackDuplicateKeys: true);
+            var key = new CollisionKey(1);
 
-            dict.Add(1, 10);
-            dict.Add(1, 20);
+            dict.Add(key, "first");
+            dict.Add(key, "second");
 
-            Assert.IsTrue(dict.Contains(1, 20));
-            Assert.IsTrue(dict.Contains(1, 10));
-            Assert.IsFalse(dict.Contains(1, 30));
+            Assert.IsTrue(dict.Contains(key, "second"));
+            Assert.IsTrue(dict.Contains(key, "first"));
+            Assert.IsFalse(dict.Contains(key, "third"));
         }
 
         [Theory]

--- a/src/Tests/Aardvark.Base.Tests/AlgoDat/DictTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/AlgoDat/DictTests.cs
@@ -356,6 +356,33 @@ namespace Aardvark.Tests
             return res;
         }
 
+        [Test]
+        public void ContainsKeyValueForCollisionChainEntry()
+        {
+            var dict = new Dict<int, int>();
+
+            // Dict starts with capacity 7, so 1 and 8 collide into the same bucket.
+            dict.Add(1, 10);
+            dict.Add(8, 20);
+
+            Assert.IsTrue(dict.Contains(1, 10));
+            Assert.IsTrue(dict.Contains(8, 20));
+            Assert.IsFalse(dict.Contains(8, 10));
+        }
+
+        [Test]
+        public void ContainsKeyValueForStackedDuplicateKeyEntry()
+        {
+            var dict = new Dict<int, int>(stackDuplicateKeys: true);
+
+            dict.Add(1, 10);
+            dict.Add(1, 20);
+
+            Assert.IsTrue(dict.Contains(1, 20));
+            Assert.IsTrue(dict.Contains(1, 10));
+            Assert.IsFalse(dict.Contains(1, 30));
+        }
+
         [Theory]
         public void ContainsValue(bool stackDuplicateKeys)
         {


### PR DESCRIPTION
## Summary
Fixes `Dict.Contains(key, value)` so collision-chain entries compare against the current entry value instead of the bucket head value.

## Notes
This PR now carries the actual fix plus regression tests that exercise the correct overload safely.
The earlier accidental direct push to `master` was removed; this PR is the intended review path.

## Validation
Run:
`dotnet test src/Tests/Aardvark.Base.Tests/Aardvark.Base.Tests.csproj -c Debug --filter FullyQualifiedName~ContainsKeyValueFor`

Also verified:
`dotnet test src/Tests/Aardvark.Base.Tests/Aardvark.Base.Tests.csproj -c Debug --filter FullyQualifiedName~DictTests`

## Test Coverage
- `ContainsKeyValueForCollisionChainEntry`
- `ContainsKeyValueForStackedDuplicateKeyEntry`

Fixes #87