### PR TITLE
Add fast values enumerator API for generated dict types

### DIFF
--- a/src/Aardvark.Base/Symbol/Dict_auto.cs
+++ b/src/Aardvark.Base/Symbol/Dict_auto.cs
@@ -1113,6 +1113,36 @@ namespace Aardvark.Base
         }
 
         /// <summary>
+        /// Gets an enumerator for values.
+        /// Should be preferred over Values enumeration in
+        /// performance critical code.
+        /// </summary>
+        public ValueEnumerator GetValuesEnumerator()
+        {
+            return new ValueEnumerator(this);
+        }
+
+        public struct ValueEnumerator : IEnumerator<TValue>
+        {
+            Dict<TKey, TValue>.Enumerator m_inner;
+
+            public ValueEnumerator(Dict<TKey, TValue> dict)
+            {
+                m_inner = dict.GetEnumerator();
+            }
+
+            public TValue Current => m_inner.Current.Value;
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose() => m_inner.Dispose();
+
+            public bool MoveNext() => m_inner.MoveNext();
+
+            public void Reset() => m_inner.Reset();
+        }
+
+        /// <summary>
         /// Gets an enumerator for values with key. It is only useful
         /// if multiple item with the same key are allowed (stackDuplicateKeys=true).
         /// The order of the values is reversed to their additions (like a stack).
@@ -3784,6 +3814,36 @@ namespace Aardvark.Base
         }
 
         /// <summary>
+        /// Gets an enumerator for values.
+        /// Should be preferred over Values enumeration in
+        /// performance critical code.
+        /// </summary>
+        public ValueEnumerator GetValuesEnumerator()
+        {
+            return new ValueEnumerator(this);
+        }
+
+        public struct ValueEnumerator : IEnumerator<TValue>
+        {
+            IntDict<TValue>.Enumerator m_inner;
+
+            public ValueEnumerator(IntDict<TValue> dict)
+            {
+                m_inner = dict.GetEnumerator();
+            }
+
+            public TValue Current => m_inner.Current.Value;
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose() => m_inner.Dispose();
+
+            public bool MoveNext() => m_inner.MoveNext();
+
+            public void Reset() => m_inner.Reset();
+        }
+
+        /// <summary>
         /// Gets an enumerator for values with key. It is only useful
         /// if multiple item with the same key are allowed (stackDuplicateKeys=true).
         /// The order of the values is reversed to their additions (like a stack).
@@ -6102,6 +6162,36 @@ namespace Aardvark.Base
                     yield return m_extraArray[ei].Item.Value;
                 ei = m_extraArray[ei].Next;
             }
+        }
+
+        /// <summary>
+        /// Gets an enumerator for values.
+        /// Should be preferred over Values enumeration in
+        /// performance critical code.
+        /// </summary>
+        public ValueEnumerator GetValuesEnumerator()
+        {
+            return new ValueEnumerator(this);
+        }
+
+        public struct ValueEnumerator : IEnumerator<TValue>
+        {
+            SymbolDict<TValue>.Enumerator m_inner;
+
+            public ValueEnumerator(SymbolDict<TValue> dict)
+            {
+                m_inner = dict.GetEnumerator();
+            }
+
+            public TValue Current => m_inner.Current.Value;
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose() => m_inner.Dispose();
+
+            public bool MoveNext() => m_inner.MoveNext();
+
+            public void Reset() => m_inner.Reset();
         }
 
         /// <summary>
@@ -8801,6 +8891,36 @@ namespace Aardvark.Base
         }
 
         /// <summary>
+        /// Gets an enumerator for values.
+        /// Should be preferred over Values enumeration in
+        /// performance critical code.
+        /// </summary>
+        public ValueEnumerator GetValuesEnumerator()
+        {
+            return new ValueEnumerator(this);
+        }
+
+        public struct ValueEnumerator : IEnumerator<TValue>
+        {
+            BigDict<TKey, TValue>.Enumerator m_inner;
+
+            public ValueEnumerator(BigDict<TKey, TValue> dict)
+            {
+                m_inner = dict.GetEnumerator();
+            }
+
+            public TValue Current => m_inner.Current.Value;
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose() => m_inner.Dispose();
+
+            public bool MoveNext() => m_inner.MoveNext();
+
+            public void Reset() => m_inner.Reset();
+        }
+
+        /// <summary>
         /// Gets an enumerator for values with key. It is only useful
         /// if multiple item with the same key are allowed (stackDuplicateKeys=true).
         /// The order of the values is reversed to their additions (like a stack).
@@ -11349,6 +11469,36 @@ namespace Aardvark.Base
                     yield return m_extraArray[ei].Item.Value;
                 ei = m_extraArray[ei].Next;
             }
+        }
+
+        /// <summary>
+        /// Gets an enumerator for values.
+        /// Should be preferred over Values enumeration in
+        /// performance critical code.
+        /// </summary>
+        public ValueEnumerator GetValuesEnumerator()
+        {
+            return new ValueEnumerator(this);
+        }
+
+        public struct ValueEnumerator : IEnumerator<TValue>
+        {
+            LongDict<TValue>.Enumerator m_inner;
+
+            public ValueEnumerator(LongDict<TValue> dict)
+            {
+                m_inner = dict.GetEnumerator();
+            }
+
+            public TValue Current => m_inner.Current.Value;
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose() => m_inner.Dispose();
+
+            public bool MoveNext() => m_inner.MoveNext();
+
+            public void Reset() => m_inner.Reset();
         }
 
         /// <summary>
@@ -29673,6 +29823,36 @@ namespace Aardvark.Base
         }
 
         /// <summary>
+        /// Gets an enumerator for values.
+        /// Should be preferred over Values enumeration in
+        /// performance critical code.
+        /// </summary>
+        public ValueEnumerator GetValuesEnumerator()
+        {
+            return new ValueEnumerator(this);
+        }
+
+        public struct ValueEnumerator : IEnumerator<TValue>
+        {
+            DictIEq<TKey, TValue>.Enumerator m_inner;
+
+            public ValueEnumerator(DictIEq<TKey, TValue> dict)
+            {
+                m_inner = dict.GetEnumerator();
+            }
+
+            public TValue Current => m_inner.Current.Value;
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose() => m_inner.Dispose();
+
+            public bool MoveNext() => m_inner.MoveNext();
+
+            public void Reset() => m_inner.Reset();
+        }
+
+        /// <summary>
         /// Gets an enumerator for values with key. It is only useful
         /// if multiple item with the same key are allowed (stackDuplicateKeys=true).
         /// The order of the values is reversed to their additions (like a stack).
@@ -32648,6 +32828,36 @@ namespace Aardvark.Base
                     yield return m_extraArray[ei].Item.Value;
                 ei = m_extraArray[ei].Next;
             }
+        }
+
+        /// <summary>
+        /// Gets an enumerator for values.
+        /// Should be preferred over Values enumeration in
+        /// performance critical code.
+        /// </summary>
+        public ValueEnumerator GetValuesEnumerator()
+        {
+            return new ValueEnumerator(this);
+        }
+
+        public struct ValueEnumerator : IEnumerator<TValue>
+        {
+            BigDictIEq<TKey, TValue>.Enumerator m_inner;
+
+            public ValueEnumerator(BigDictIEq<TKey, TValue> dict)
+            {
+                m_inner = dict.GetEnumerator();
+            }
+
+            public TValue Current => m_inner.Current.Value;
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose() => m_inner.Dispose();
+
+            public bool MoveNext() => m_inner.MoveNext();
+
+            public void Reset() => m_inner.Reset();
         }
 
         /// <summary>

--- a/src/Aardvark.Base/Symbol/Dict_template.cs
+++ b/src/Aardvark.Base/Symbol/Dict_template.cs
@@ -1289,6 +1289,36 @@ namespace Aardvark.Base
 
         //# if (!concurrent) {
         /// <summary>
+        /// Gets an enumerator for values.
+        /// Should be preferred over Values enumeration in
+        /// performance critical code.
+        /// </summary>
+        public ValueEnumerator GetValuesEnumerator()
+        {
+            return new ValueEnumerator(this);
+        }
+
+        public struct ValueEnumerator : IEnumerator<TValue>
+        {
+            __type__/*# if (isGeneric) { */</*# if (hasKey) { */TKey/*# } if (hasValue) { if (hasKey) { */, /*# } */TValue/*# } */>/*# } */.Enumerator m_inner;
+
+            public ValueEnumerator(__type__/*# if (isGeneric) { */</*# if (hasKey) { */TKey/*# } if (hasValue) { if (hasKey) { */, /*# } */TValue/*# } */>/*# } */ dict)
+            {
+                m_inner = dict.GetEnumerator();
+            }
+
+            public TValue Current => m_inner.Current.Value;
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose() => m_inner.Dispose();
+
+            public bool MoveNext() => m_inner.MoveNext();
+
+            public void Reset() => m_inner.Reset();
+        }
+
+        /// <summary>
         /// Gets an enumerator for values with key. It is only useful
         /// if multiple item with the same key are allowed (stackDuplicateKeys=true).
         /// The order of the values is reversed to their additions (like a stack).

--- a/src/Tests/Aardvark.Base.Benchmarks/Enumerators.cs
+++ b/src/Tests/Aardvark.Base.Benchmarks/Enumerators.cs
@@ -49,6 +49,8 @@ namespace Aardvark.Base.Benchmarks
     //| ForEachSymbolDictValues |   100 | 632.1000 ns | 7.6100 ns | 7.1200 ns |
 
     [PlainExporter]
+    [MemoryDiagnoser]
+    [ShortRunJob]
     public class Enumerators
     {
         int[] m_array;
@@ -153,6 +155,16 @@ namespace Aardvark.Base.Benchmarks
         }
 
         [Benchmark]
+        public int ForEachDictFastValues()
+        {
+            int sum = 0;
+            var values = m_dict.GetValuesEnumerator();
+            while (values.MoveNext())
+                sum += values.Current;
+            return sum;
+        }
+
+        [Benchmark]
         public int ForEachDictKeys()
         {
             int sum = 0;
@@ -179,6 +191,16 @@ namespace Aardvark.Base.Benchmarks
             return sum;
         }
 
+        [Benchmark]
+        public int ForEachSymbolDictFastValues()
+        {
+            int sum = 0;
+            var values = m_symDict.GetValuesEnumerator();
+            while (values.MoveNext())
+                sum += values.Current;
+            return sum;
+        }
+
         [Test]
         public void Test()
         {
@@ -196,9 +218,11 @@ namespace Aardvark.Base.Benchmarks
                 Assert.IsTrue(refSum == ForEachDictionary());
                 Assert.IsTrue(refSum == ForEachIntSet());
                 Assert.IsTrue(refSum == ForEachDictValues());
+                Assert.IsTrue(refSum == ForEachDictFastValues());
                 Assert.IsTrue(refSum == ForEachDictKeys());
                 Assert.IsTrue(refSum == ForEachDict());
                 Assert.IsTrue(refSum == ForEachSymbolDictValues());
+                Assert.IsTrue(refSum == ForEachSymbolDictFastValues());
             }
         }
     }

--- a/src/Tests/Aardvark.Base.Benchmarks/Program.cs
+++ b/src/Tests/Aardvark.Base.Benchmarks/Program.cs
@@ -9,7 +9,12 @@ namespace Aardvark.Base.Benchmarks
         public static void Main(string[] args)
         {
             var cfg = ManualConfig.Create(DefaultConfig.Instance).WithOptions(ConfigOptions.DisableOptimizationsValidator);
-            //BenchmarkSwitcher.FromAssembly(typeof(IntegerPowerFloat).Assembly).Run(args, cfg);
+            var switcher = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly);
+            if (args.Length > 0)
+            {
+                switcher.Run(args, cfg);
+                return;
+            }
 
             //BenchmarkRunner.Run<HashBench>(cfg);
             //BenchmarkRunner.Run<StreamWriterReader>(cfg);

--- a/src/Tests/Aardvark.Base.Tests/AlgoDat/DictTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/AlgoDat/DictTests.cs
@@ -507,6 +507,53 @@ namespace Aardvark.Tests
         }
 
         [Theory]
+        public void FastValuesEnumeratorMatchesValues(bool stackDuplicateKeys)
+        {
+            Dict<int, int> dict = new(stackDuplicateKeys)
+            {
+                {1, 2},
+                {2, 3},
+                {3, 4},
+                {42, 5},
+                {-13, 7},
+            };
+
+            if (stackDuplicateKeys)
+            {
+                dict.Add(42, 80);
+                dict.Add(42, -80);
+            }
+
+            CollectionAssert.AreEqual(dict.Values.ToArray(), EnumerateFastValues(dict));
+        }
+
+        [Test]
+        public void FastValuesEnumeratorEmpty()
+        {
+            var dict = new Dict<int, int>();
+            var values = dict.GetValuesEnumerator();
+            Assert.IsFalse(values.MoveNext());
+
+            var symbolDict = new SymbolDict<int>();
+            var symbolValues = symbolDict.GetValuesEnumerator();
+            Assert.IsFalse(symbolValues.MoveNext());
+        }
+
+        [Test]
+        public void SymbolDictFastValuesEnumeratorMatchesValues()
+        {
+            var dict = new SymbolDict<int>
+            {
+                { "one", 1 },
+                { "two", 2 },
+                { "three", 3 },
+                { "four", 4 },
+            };
+
+            CollectionAssert.AreEqual(dict.Values.ToArray(), EnumerateFastValues(dict));
+        }
+
+        [Theory]
         public void IDictionaryKeys(bool stackDuplicateKeys)
         {
             Dict<int, int> dict = new(stackDuplicateKeys)
@@ -568,6 +615,28 @@ namespace Aardvark.Tests
 
             Assert.AreEqual(expectedValues.Length, values.Count);
             Assert.AreEqual(expectedValues, actualValues);
+        }
+
+        private static int[] EnumerateFastValues(Dict<int, int> dict)
+        {
+            var result = new List<int>();
+            var values = dict.GetValuesEnumerator();
+
+            while (values.MoveNext())
+                result.Add(values.Current);
+
+            return result.ToArray();
+        }
+
+        private static int[] EnumerateFastValues(SymbolDict<int> dict)
+        {
+            var result = new List<int>();
+            var values = dict.GetValuesEnumerator();
+
+            while (values.MoveNext())
+                result.Add(values.Current);
+
+            return result.ToArray();
         }
     }
 }


### PR DESCRIPTION
Closes #89.

This adds a non-breaking fast values enumeration API for the generated dict types.

Changes:
- add `GetValuesEnumerator()` and `ValueEnumerator` to the non-concurrent value-bearing generated dict variants
- keep `Values : IEnumerable<TValue>` unchanged for compatibility
- add focused `DictTests` coverage for `Dict<int, int>` and `SymbolDict<int>`
- add focused benchmark comparisons and make the benchmark entrypoint accept filtered execution

Performance from one local BenchmarkDotNet run (`Count=100`):
- `Dict<int, int>`: `ForEachDictValues` `214.49 ns`, `48 B` -> `ForEachDictFastValues` `194.12 ns`, `0 B`
- `SymbolDict<int>`: `ForEachSymbolDictValues` `213.80 ns`, `48 B` -> `ForEachSymbolDictFastValues` `178.41 ns`, `0 B`

Validation:
- `dotnet test src/Tests/Aardvark.Base.Tests/Aardvark.Base.Tests.csproj -c Debug --filter FullyQualifiedName~DictTests`
- `dotnet build src/Tests/Aardvark.Base.Benchmarks/Aardvark.Base.Benchmarks.csproj -c Release`
- `dotnet run --project src/Tests/Aardvark.Base.Benchmarks/Aardvark.Base.Benchmarks.csproj -c Release -- --filter *Enumerators*`

cc @stefanmaierhofer @hyazinthh