### PR TITLE
Add --force mode to CodeGenerator and verify generated files in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   codegen-check:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
 
@@ -32,18 +32,22 @@ jobs:
           ${{ runner.os }}-paket-
 
     - name: Restore
-      run: bash ./build.sh restore
+      shell: cmd
+      run: .\build.cmd restore
 
     - name: Run forced code generation
-      run: bash ./generate.sh --force
+      shell: cmd
+      run: .\generate.cmd --force
 
     - name: Fail on generated diffs
+      shell: pwsh
       run: |
-        if ! git diff --quiet -- src; then
-          echo "Generated files are out of date:"
+        git diff --quiet -- src
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "Generated files are out of date:"
           git diff --name-only -- src
           exit 1
-        fi
+        }
 
   build:
     needs: codegen-check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,42 @@ on:
     - 'docs/**'
 
 jobs:
+  codegen-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+
+    - name: Cache Paket
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.nuget/packages
+          paket-files
+        key: ${{ runner.os }}-paket-${{ hashFiles('paket.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-paket-
+
+    - name: Restore
+      run: bash ./build.sh restore
+
+    - name: Run forced code generation
+      run: bash ./generate.sh --force
+
+    - name: Fail on generated diffs
+      run: |
+        if ! git diff --quiet -- src; then
+          echo "Generated files are out of date:"
+          git diff --name-only -- src
+          exit 1
+        fi
+
   build:
+    needs: codegen-check
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -63,12 +63,16 @@ If you changed templates (`*_template.cs` / `*_template.fs`), regenerate:
 ```bash
 # Windows
 .\generate.cmd
+.\generate.cmd --force
 
 # Linux/macOS
 ./generate.sh
+./generate.sh --force
 ```
 
 Do not edit generated `*_auto.cs` / `*_auto.fs` manually.
+The scripts forward generator CLI arguments, so `--force` can be used for a full regeneration pass.
+CI uses forced regeneration to detect stale generated files.
 
 ## Dependency Management
 

--- a/generate.cmd
+++ b/generate.cmd
@@ -1,3 +1,3 @@
 @echo off
 dotnet build src\CodeGenerator\CodeGenerator.csproj
-dotnet bin\Debug\net8.0\CodeGenerator.dll
+dotnet bin\Debug\net8.0\CodeGenerator.dll %*

--- a/generate.sh
+++ b/generate.sh
@@ -1,3 +1,3 @@
 #! /bin/sh
 dotnet build src/CodeGenerator/CodeGenerator.csproj
-dotnet bin/Debug/net8.0/CodeGenerator.dll
+dotnet bin/Debug/net8.0/CodeGenerator.dll "$@"

--- a/src/CodeGenerator/Program.cs
+++ b/src/CodeGenerator/Program.cs
@@ -50,20 +50,47 @@ namespace CodeGenerator
             return File.GetLastWriteTimeUtc(fileName1) < File.GetLastWriteTimeUtc(fileName2);
         }
 
+        private static void ShowUsage()
+        {
+            Console.Error.WriteLine(
+                "Usage: CodeGenerator [-f|--force] [<directory>|<config.conf>|<template> <output>]");
+        }
+
         [STAThread]
         public static void Main(string[] args)
         {
             Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
 
             var tasks = new List<Task>();
+            var positionalArgs = new List<string>();
             string dir = null;
+            bool force = false;
             bool writeGenerator = true;
 
-            if (args.Length > 0)
+            foreach (var arg in args)
             {
-                if (args[0].EndsWith(".conf"))
+                switch (arg)
                 {
-                    foreach (var line in File.ReadAllLines(args[0]))
+                    case "-f":
+                    case "--force":
+                        force = true;
+                        break;
+
+                    default:
+                        positionalArgs.Add(arg);
+                        break;
+                }
+            }
+
+            if (positionalArgs.Count == 0)
+            {
+                dir = Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location),"..", "..", "..");
+            }
+            else if (positionalArgs.Count == 1)
+            {
+                if (positionalArgs[0].EndsWith(".conf"))
+                {
+                    foreach (var line in File.ReadAllLines(positionalArgs[0]))
                     {
                         var parts = line.Split(new [] { ' ', '\t' },
                                     StringSplitOptions.RemoveEmptyEntries);
@@ -74,13 +101,29 @@ namespace CodeGenerator
                         });
                     }
                 }
-                else if (Directory.Exists(args[0]))
-                    dir = args[0];
+                else if (Directory.Exists(positionalArgs[0]))
+                {
+                    dir = positionalArgs[0];
+                }
                 else
-                    tasks.Add(new Task { TemplateFileName = args[0], OutputFileName = args[1] });
+                {
+                    ShowUsage();
+                    Environment.Exit(1);
+                }
+            }
+            else if (positionalArgs.Count == 2)
+            {
+                tasks.Add(new Task
+                {
+                    TemplateFileName = positionalArgs[0],
+                    OutputFileName = positionalArgs[1]
+                });
             }
             else
-                dir = Path.Combine(Path.GetDirectoryName(typeof(Program).Assembly.Location),"..", "..", "..");
+            {
+                ShowUsage();
+                Environment.Exit(1);
+            }
 
             if (dir != null)
             {
@@ -106,7 +149,8 @@ namespace CodeGenerator
             {
                 string report = task.Report ?? task.OutputFileName;
 
-                if (task.TemplateFileName != null &&
+                if (!force &&
+                    task.TemplateFileName != null &&
                     IsOlderThan(task.TemplateFileName, task.OutputFileName))
                 {
                     Console.WriteLine("- {0}", report);

--- a/src/CodeGenerator/README.md
+++ b/src/CodeGenerator/README.md
@@ -16,24 +16,32 @@ This approach keeps the codebase DRY (Don't Repeat Yourself) by maintaining a si
 ### Using the shell script (Unix/Linux/macOS)
 ```bash
 ./generate.sh
+./generate.sh --force
 ```
 
 ### Using the command script (Windows)
 ```cmd
 generate.cmd
+generate.cmd --force
 ```
 
 ### Using dotnet directly
 ```bash
 dotnet run --project src/CodeGenerator/CodeGenerator.csproj
+dotnet run --project src/CodeGenerator/CodeGenerator.csproj -- --force
 ```
+
+Both wrapper scripts forward additional CLI arguments to `CodeGenerator.dll`.
 
 ## When to Run
 
 Run the code generator **immediately after modifying any `*_template.cs` file**. The generator:
 - Detects which template files have been modified since their output was last generated
 - Only regenerates files that need updating (skips unchanged templates)
+- Can regenerate everything with `-f` / `--force`, regardless of timestamps
 - Must be run before building/testing to ensure generated code is up-to-date
+
+Use `--force` when you want a deterministic full regeneration pass, for example in CI when verifying that committed `*_auto.*` files match their templates.
 
 The scripts print:
 - `#` prefix: Template is being processed (newer than output)


### PR DESCRIPTION
## Summary

- add `-f` / `--force` to `CodeGenerator`
- forward generator arguments through `generate.cmd` and `generate.sh`
- add CI verification that reruns code generation and fails on tracked diffs
- document the new flag and the CI verification flow

Closes #91

## Validation

- `dotnet build src\CodeGenerator\CodeGenerator.csproj -c Debug`
- `.\generate.cmd --force`
- `.\generate.cmd`
- `.\build.cmd`
- `.\check-docs.cmd`