### PR TITLE
Harden incomplete introspection scans

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,4 @@
+- [Base] Bounded introspection failure diagnostics and prevented caching incomplete scans
 - [Tests] Benchmarked actual float/double 2D/3D plane-clipping overloads without duplicated baselines
 - [Base] Added allocation-free 2D/3D line-segment clipping against plane half-spaces
 - [Base] Fixed duplicate introspection method-query cache entries

--- a/ai/UTILITIES.md
+++ b/ai/UTILITIES.md
@@ -71,7 +71,7 @@ element hash directly, and each later element hash is incorporated with
 disposes its enumerator, so the same ordered values hash identically regardless
 of whether the caller exposes them as an array, list, or lazy sequence.
 
-## Introspection Method Queries
+## Introspection Queries
 
 `Introspection.GetAllMethodsWithAttribute<T>(Assembly)` scans public instance
 and static methods declared directly by each assembly type. Each matching
@@ -81,6 +81,16 @@ The version-1 query cache stores one assembly-qualified name per declaring type
 in first-seen order. Cache reads deduplicate declaring-type lines before resolving
 and scanning them, so legacy files containing repeated lines produce the same
 method sequence and count as a cache miss.
+
+Introspection queries retain successful matches when loading types, enumerating
+methods, or constructing attributes fails. Reflection failures are reported once
+per assembly and query as a bounded summary with deduplicated examples; full
+exception stacks and repeated per-member messages are not emitted.
+
+Only complete live scans are cached. An incomplete cache decode is discarded and
+retried against the live assembly, while an incomplete live scan leaves no cache
+entry. A later complete scan can therefore repopulate the same version-1 cache
+after a transient dependency or attribute-construction failure.
 
 ## Random
 

--- a/src/Aardvark.Base/Introspection/Introspection.cs
+++ b/src/Aardvark.Base/Introspection/Introspection.cs
@@ -80,43 +80,50 @@ public static class Introspection
 
     /// <summary>
     /// Enumerates all classes from the specified assembly
-    /// implementing the specified interface.
+    /// implementing the specified interface. Successful matches are retained if
+    /// inspecting another type fails; incomplete live scans are not cached.
     /// </summary>
     public static Type[] GetAllClassesImplementingInterface(Assembly assembly, Type interfaceType)
         => GetAll___(assembly, interfaceType.FullName,
-            lines => lines.SelectNotNull(GetType),
-            types => types.Where(t => (t.IsClass || t.IsValueType) && t.GetInterfaces().Contains(interfaceType)),
+            (IEnumerable<string> lines, ref QueryDiagnostics diagnostics) =>
+                ResolveTypes(lines, false, ref diagnostics),
+            (Type[] types, ref QueryDiagnostics diagnostics) =>
+                FilterTypes(types,
+                    t => (t.IsClass || t.IsValueType) && t.GetInterfaces().Contains(interfaceType),
+                    ref diagnostics),
             result => result.Select(t => t.AssemblyQualifiedName)
         );
 
     /// <summary>
     /// Enumerates all classes from the specified assembly
-    /// inheriting from the specified base class.
+    /// inheriting from the specified base class. Successful matches are retained
+    /// if inspecting another type fails; incomplete live scans are not cached.
     /// </summary>
     public static Type[] GetAllClassesInheritingFrom(Assembly assembly, Type baseType)
         => GetAll___(assembly, baseType.FullName,
-            lines => lines.SelectNotNull(GetType),
-            types => types.Where(t => t.IsSubclassOf(baseType)),
+            (IEnumerable<string> lines, ref QueryDiagnostics diagnostics) =>
+                ResolveTypes(lines, false, ref diagnostics),
+            (Type[] types, ref QueryDiagnostics diagnostics) =>
+                FilterTypes(types, t => t.IsSubclassOf(baseType), ref diagnostics),
             result => result.Select(t => t.AssemblyQualifiedName)
         );
 
     /// <summary>
     /// Enumerates all types from the specified assembly
     /// decorated with attribute T as tuples of type
-    /// and its one or more T-attributes.
+    /// and its one or more T-attributes. Successful matches are retained when
+    /// other attributes cannot be constructed; incomplete live scans are not cached.
     /// </summary>
     public static (Type, T[])[] GetAllTypesWithAttribute<T>(Assembly assembly)
         => GetAll___<(Type, T[])>(assembly, typeof(T).FullName,
-           lines => lines.SelectNotNull(GetType)
-                    .Select(t => (t, TryGetCustomAttributes<T>(t))),
-           types => from t in types
-                    let attribs = TryGetCustomAttributes<T>(t)
-                    where attribs.Length > 0
-                    select (t, attribs),
+           (IEnumerable<string> lines, ref QueryDiagnostics diagnostics) =>
+                DecodeTypesWithAttribute<T>(lines, ref diagnostics),
+           (Type[] types, ref QueryDiagnostics diagnostics) =>
+                GetTypesWithAttribute<T>(types, ref diagnostics),
            result => result.Select(t => t.Item1.AssemblyQualifiedName)
         );
 
-    private static T[] TryGetCustomAttributes<T>(Type type)
+    private static T[] GetCustomAttributes<T>(Type type, ref QueryDiagnostics diagnostics)
     {
         if (type == null) return [];
         try
@@ -125,12 +132,12 @@ public static class Introspection
         }
         catch (Exception e)
         {
-            Report.Line(3, "[Introspection] Failed to get custom attributes for {0}: {1} ({2})", type.FullName, e.Message, e.GetType().Name);
+            AddDiagnostic(ref diagnostics, DiagnosticKind.TypeAttributes, GetTypeNameSafe(type), e);
         }
         return [];
     }
 
-    private static T[] TryGetCustomAttributes<T>(MethodInfo mi)
+    private static T[] GetCustomAttributes<T>(MethodInfo mi, ref QueryDiagnostics diagnostics)
     {
         if (mi == null) return [];
         try
@@ -139,7 +146,8 @@ public static class Introspection
         }
         catch (Exception e)
         {
-            Report.Line(3, "[Introspection] Failed to get custom attributes for {0}.{1}: {2} ({3})", mi.DeclaringType?.FullName, mi.Name, e.Message, e.GetType().Name);
+            AddDiagnostic(ref diagnostics, DiagnosticKind.MethodAttributes,
+                GetMethodNameSafe(mi), e);
         }
         return [];
     }
@@ -147,22 +155,47 @@ public static class Introspection
     private const BindingFlags PublicDeclaredMethods =
         BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
 
-    private static IEnumerable<(MethodInfo, T[])> GetMethodsWithAttribute<T>(IEnumerable<Type> types)
+    private static ScanResult<(MethodInfo, T[])> GetMethodsWithAttribute<T>(
+        Type[] types, ref QueryDiagnostics diagnostics
+    )
     {
+        var initialFailureCount = GetFailureCount(diagnostics);
+        var result = new List<(MethodInfo, T[])>();
+
         foreach (var type in types)
         {
             if (type == null) continue;
 
-            foreach (var method in type.GetMethods(PublicDeclaredMethods))
+            MethodInfo[] methods;
+            try
             {
-                var attributes = TryGetCustomAttributes<T>(method);
-                if (attributes.Length > 0) yield return (method, attributes);
+                methods = type.GetMethods(PublicDeclaredMethods) ?? [];
+            }
+            catch (Exception e)
+            {
+                AddDiagnostic(ref diagnostics, DiagnosticKind.MethodEnumeration,
+                    GetTypeNameSafe(type), e);
+                continue;
+            }
+
+            foreach (var method in methods)
+            {
+                var attributes = GetCustomAttributes<T>(method, ref diagnostics);
+                if (attributes.Length > 0) result.Add((method, attributes));
             }
         }
+
+        return new ScanResult<(MethodInfo, T[])>(
+            result.ToArray(), GetFailureCount(diagnostics) != initialFailureCount
+        );
     }
 
-    private static IEnumerable<Type> ResolveUniqueTypes(IEnumerable<string> lines)
+    private static ScanResult<Type> ResolveTypes(
+        IEnumerable<string> lines, bool unique, ref QueryDiagnostics diagnostics
+    )
     {
+        var initialFailureCount = GetFailureCount(diagnostics);
+        var result = new List<Type>();
         string first = null;
         HashSet<string> seen = null;
 
@@ -170,19 +203,103 @@ public static class Introspection
         {
             if (line == null) continue;
 
-            if (first == null)
+            if (unique && first == null)
             {
                 first = line;
             }
-            else
+            else if (unique)
             {
                 seen ??= new HashSet<string>(StringComparer.Ordinal) { first };
                 if (!seen.Add(line)) continue;
             }
 
-            var type = GetType(line);
-            if (type != null) yield return type;
+            try
+            {
+                var type = GetType(line);
+                if (type != null)
+                {
+                    result.Add(type);
+                }
+                else
+                {
+                    AddDiagnostic(ref diagnostics, DiagnosticKind.CacheTypeResolution, line,
+                        nameof(TypeLoadException), "Cached type could not be resolved.");
+                }
+            }
+            catch (Exception e)
+            {
+                AddDiagnostic(ref diagnostics, DiagnosticKind.CacheTypeResolution, line, e);
+            }
         }
+
+        return new ScanResult<Type>(
+            result.ToArray(), GetFailureCount(diagnostics) != initialFailureCount
+        );
+    }
+
+    private static ScanResult<Type> FilterTypes(
+        Type[] types, Func<Type, bool> predicate, ref QueryDiagnostics diagnostics
+    )
+    {
+        var initialFailureCount = GetFailureCount(diagnostics);
+        var result = new List<Type>();
+
+        foreach (var type in types)
+        {
+            if (type == null) continue;
+
+            try
+            {
+                if (predicate(type)) result.Add(type);
+            }
+            catch (Exception e)
+            {
+                AddDiagnostic(ref diagnostics, DiagnosticKind.TypeInspection,
+                    GetTypeNameSafe(type), e);
+            }
+        }
+
+        return new ScanResult<Type>(
+            result.ToArray(), GetFailureCount(diagnostics) != initialFailureCount
+        );
+    }
+
+    private static ScanResult<(Type, T[])> DecodeTypesWithAttribute<T>(
+        IEnumerable<string> lines, ref QueryDiagnostics diagnostics
+    )
+    {
+        var resolved = ResolveTypes(lines, false, ref diagnostics);
+        var result = GetTypesWithAttribute<T>(resolved.Items, ref diagnostics);
+        return new ScanResult<(Type, T[])>(result.Items, resolved.Incomplete || result.Incomplete);
+    }
+
+    private static ScanResult<(Type, T[])> GetTypesWithAttribute<T>(
+        Type[] types, ref QueryDiagnostics diagnostics
+    )
+    {
+        var initialFailureCount = GetFailureCount(diagnostics);
+        var result = new List<(Type, T[])>();
+
+        foreach (var type in types)
+        {
+            if (type == null) continue;
+
+            var attributes = GetCustomAttributes<T>(type, ref diagnostics);
+            if (attributes.Length > 0) result.Add((type, attributes));
+        }
+
+        return new ScanResult<(Type, T[])>(
+            result.ToArray(), GetFailureCount(diagnostics) != initialFailureCount
+        );
+    }
+
+    private static ScanResult<(MethodInfo, T[])> DecodeMethodsWithAttribute<T>(
+        IEnumerable<string> lines, ref QueryDiagnostics diagnostics
+    )
+    {
+        var resolved = ResolveTypes(lines, true, ref diagnostics);
+        var result = GetMethodsWithAttribute<T>(resolved.Items, ref diagnostics);
+        return new ScanResult<(MethodInfo, T[])>(result.Items, resolved.Incomplete || result.Incomplete);
     }
 
     private static IEnumerable<string> GetUniqueDeclaringTypeNames<T>((MethodInfo, T[])[] methods)
@@ -213,12 +330,16 @@ public static class Introspection
     /// Enumerates public instance and static methods declared by types in the specified
     /// assembly and decorated with attribute T. Each method is returned once together
     /// with all of its T-attribute instances. The query cache stores each declaring type
-    /// once and ignores repeated declaring-type lines in legacy cache files.
+    /// once and ignores repeated declaring-type lines in legacy cache files. Successful
+    /// matches are retained when other reflection operations fail; incomplete cache
+    /// entries are retried live and incomplete live scans are not cached.
     /// </summary>
     public static (MethodInfo, T[])[] GetAllMethodsWithAttribute<T>(Assembly assembly)
         => GetAll___<(MethodInfo, T[])>(assembly, typeof(T).FullName,
-              lines => GetMethodsWithAttribute<T>(ResolveUniqueTypes(lines)),
-              types => GetMethodsWithAttribute<T>(types),
+              (IEnumerable<string> lines, ref QueryDiagnostics diagnostics) =>
+                  DecodeMethodsWithAttribute<T>(lines, ref diagnostics),
+              (Type[] types, ref QueryDiagnostics diagnostics) =>
+                  GetMethodsWithAttribute<T>(types, ref diagnostics),
               GetUniqueDeclaringTypeNames
         );
 
@@ -394,15 +515,262 @@ public static class Introspection
             };
         }
     }
+
+    private enum DiagnosticKind
+    {
+        LoaderExceptions,
+        TypeEnumeration,
+        CacheTypeResolution,
+        TypeInspection,
+        TypeAttributes,
+        MethodEnumeration,
+        MethodAttributes,
+        CacheAccess,
+    }
+
+    private sealed class DiagnosticExample
+    {
+        public readonly string ExceptionType;
+        public readonly string Message;
+        public readonly string Subject;
+
+        public DiagnosticExample(string exceptionType, string message, string subject)
+        {
+            ExceptionType = exceptionType;
+            Message = message;
+            Subject = subject;
+        }
+    }
+
+    private sealed class DiagnosticGroup
+    {
+        private const int MaxExamples = 3;
+        private readonly HashSet<string> m_unique = new(StringComparer.Ordinal);
+        private readonly List<DiagnosticExample> m_examples = [];
+
+        public int Count { get; private set; }
+        public int UniqueCount => m_unique.Count;
+        public IReadOnlyList<DiagnosticExample> Examples => m_examples;
+
+        public void Add(string exceptionType, string message, string subject)
+        {
+            Count++;
+            var key = $"{exceptionType}\n{message}";
+            if (!m_unique.Add(key)) return;
+            if (m_examples.Count < MaxExamples)
+                m_examples.Add(new DiagnosticExample(exceptionType, message, subject));
+        }
+    }
+
+    private sealed class QueryDiagnostics
+    {
+        private readonly DiagnosticGroup[] m_groups =
+            new DiagnosticGroup[(int)DiagnosticKind.CacheAccess + 1];
+
+        public int FailureCount { get; private set; }
+        public int ReflectionTypeLoadCount { get; private set; }
+
+        public void Add(DiagnosticKind kind, string subject, string exceptionType, string message)
+        {
+            FailureCount++;
+            var index = (int)kind;
+            var group = m_groups[index] ??= new DiagnosticGroup();
+            group.Add(Compact(exceptionType), Compact(message), Compact(subject));
+        }
+
+        public void Add(ReflectionTypeLoadException exception)
+        {
+            ReflectionTypeLoadCount++;
+            var loaderExceptions = exception.LoaderExceptions;
+            if (loaderExceptions == null || loaderExceptions.Length == 0)
+            {
+                Add(DiagnosticKind.LoaderExceptions, null, exception.GetType().Name, exception.Message);
+                return;
+            }
+
+            var added = false;
+            foreach (var loaderException in loaderExceptions)
+            {
+                if (loaderException == null) continue;
+                var unwrapped = Unwrap(loaderException);
+                Add(DiagnosticKind.LoaderExceptions, null, unwrapped.GetType().Name, unwrapped.Message);
+                added = true;
+            }
+
+            if (!added)
+                Add(DiagnosticKind.LoaderExceptions, null, exception.GetType().Name, exception.Message);
+        }
+
+        public DiagnosticGroup GetGroup(DiagnosticKind kind) => m_groups[(int)kind];
+
+        private static string Compact(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return value ?? "";
+
+            const int maxLength = 240;
+            var compact = value.Replace('\r', ' ').Replace('\n', ' ');
+            return compact.Length <= maxLength ? compact : compact.Substring(0, maxLength) + "...";
+        }
+    }
+
+    private readonly struct ScanResult<T>
+    {
+        public readonly T[] Items;
+        public readonly bool Incomplete;
+
+        public ScanResult(T[] items, bool incomplete)
+        {
+            Items = items;
+            Incomplete = incomplete;
+        }
+    }
+
+    private delegate ScanResult<T> DecodeQuery<T>(
+        IEnumerable<string> lines, ref QueryDiagnostics diagnostics
+    );
+
+    private delegate ScanResult<T> ScanTypes<T>(
+        Type[] types, ref QueryDiagnostics diagnostics
+    );
+
+    private static int GetFailureCount(QueryDiagnostics diagnostics)
+        => diagnostics?.FailureCount ?? 0;
+
+    private static Exception Unwrap(Exception exception)
+    {
+        while (exception is TargetInvocationException && exception.InnerException != null)
+            exception = exception.InnerException;
+        return exception;
+    }
+
+    private static string GetTypeNameSafe(Type type)
+    {
+        if (type == null) return "<unknown type>";
+        try
+        {
+            return type.FullName ?? type.Name ?? "<unknown type>";
+        }
+        catch
+        {
+            return "<unknown type>";
+        }
+    }
+
+    private static string GetMethodNameSafe(MethodInfo method)
+    {
+        if (method == null) return "<unknown method>";
+        try
+        {
+            return $"{GetTypeNameSafe(method.DeclaringType)}.{method.Name}";
+        }
+        catch
+        {
+            return "<unknown method>";
+        }
+    }
+
+    private static string GetAssemblyNameSafe(Assembly assembly)
+    {
+        if (assembly == null) return "<unknown assembly>";
+        try
+        {
+            return assembly.GetName()?.Name ?? assembly.FullName ?? "<unknown assembly>";
+        }
+        catch
+        {
+            return "<unknown assembly>";
+        }
+    }
+
+    private static void AddDiagnostic(
+        ref QueryDiagnostics diagnostics, DiagnosticKind kind, string subject, Exception exception
+    )
+    {
+        exception = Unwrap(exception);
+        AddDiagnostic(ref diagnostics, kind, subject, exception.GetType().Name, exception.Message);
+    }
+
+    private static void AddDiagnostic(
+        ref QueryDiagnostics diagnostics, DiagnosticKind kind, string subject,
+        string exceptionType, string message
+    )
+    {
+        diagnostics ??= new QueryDiagnostics();
+        diagnostics.Add(kind, subject, exceptionType, message);
+    }
+
+    private static string GetDiagnosticLabel(DiagnosticKind kind)
+    {
+        return kind switch
+        {
+            DiagnosticKind.LoaderExceptions => "loader exceptions",
+            DiagnosticKind.TypeEnumeration => "type enumeration",
+            DiagnosticKind.CacheTypeResolution => "cached type resolution",
+            DiagnosticKind.TypeInspection => "type inspection",
+            DiagnosticKind.TypeAttributes => "type attribute construction",
+            DiagnosticKind.MethodEnumeration => "method enumeration",
+            DiagnosticKind.MethodAttributes => "method attribute construction",
+            DiagnosticKind.CacheAccess => "cache access",
+            _ => "unknown",
+        };
+    }
+
+    private static void ReportDiagnostics(
+        Assembly assembly, string discriminator, QueryDiagnostics diagnostics
+    )
+    {
+        if (diagnostics == null) return;
+
+        Report.Begin(3,
+            "[Introspection] Query {0} for assembly {1} encountered {2} failure(s)",
+            discriminator, GetAssemblyNameSafe(assembly), diagnostics.FailureCount);
+        try
+        {
+            if (diagnostics.ReflectionTypeLoadCount > 0)
+            {
+                Report.Line(3, "ReflectionTypeLoadException affected {0} assembly type scan(s).",
+                    diagnostics.ReflectionTypeLoadCount);
+            }
+
+            for (var i = 0; i <= (int)DiagnosticKind.CacheAccess; i++)
+            {
+                var kind = (DiagnosticKind)i;
+                var group = diagnostics.GetGroup(kind);
+                if (group == null) continue;
+
+                Report.Line(3, "{0}: {1} failure(s), {2} unique diagnostic(s).",
+                    GetDiagnosticLabel(kind), group.Count, group.UniqueCount);
+
+                foreach (var example in group.Examples)
+                {
+                    if (string.IsNullOrEmpty(example.Subject))
+                        Report.Line(3, "  {0}: {1}", example.ExceptionType, example.Message);
+                    else
+                        Report.Line(3, "  {0}: {1} [{2}]",
+                            example.ExceptionType, example.Message, example.Subject);
+                }
+
+                var omitted = group.UniqueCount - group.Examples.Count;
+                if (omitted > 0)
+                    Report.Line(3, "  {0} additional unique diagnostic(s) omitted.", omitted);
+            }
+        }
+        finally
+        {
+            Report.End(3);
+        }
+    }
+
     private static T[] GetAll___<T>(
         Assembly a, string discriminator,
-        Func<IEnumerable<string>, IEnumerable<T>> decode,
-        Func<IEnumerable<Type>, IEnumerable<T>> createResult,
+        DecodeQuery<T> decode,
+        ScanTypes<T> createResult,
         Func<T[], IEnumerable<string>> encode
         )
     {
         var cacheFileName = "";
         var assemblyTimeStamp = DateTime.MinValue;
+        QueryDiagnostics diagnostics = null;
 
         // whatever happens, don't halt just because of caching... this actually happens for self-contained deployments https://github.com/aardvark-platform/aardvark.base/issues/65
         try
@@ -417,14 +785,29 @@ public static class Introspection
                 var header = lines.Length > 0 ? CacheFileHeader.Parse(lines[0]) : null;
                 if (header != null && header.TimeStampOfCachedFile == assemblyTimeStamp)
                 {
-                    // return cached types
                     Report.Line(4, "[cache hit ] {0}", a);
-                    return decode(lines.Skip(1)).ToArray();
+                    ScanResult<T> cached;
+                    try
+                    {
+                        cached = decode(lines.Skip(1), ref diagnostics);
+                    }
+                    catch (Exception e)
+                    {
+                        AddDiagnostic(ref diagnostics, DiagnosticKind.CacheAccess,
+                            cacheFileName, e);
+                        cached = new ScanResult<T>([], true);
+                    }
+
+                    if (!cached.Incomplete) return cached.Items;
+
+                    TryDeleteCacheFile(cacheFileName, ref diagnostics);
+                    Report.Line(3, "[Introspection] Retrying incomplete cache query live for {0}", a);
                 }
             }
-        } catch(Exception e)
+        }
+        catch(Exception e)
         {
-            Report.Warn("Could not get cache for {1}: {0}", e.Message, a.FullName);
+            AddDiagnostic(ref diagnostics, DiagnosticKind.CacheAccess, cacheFileName, e);
         }
 
         Report.Line(4, "[cache miss] {0}", a);
@@ -435,49 +818,82 @@ public static class Introspection
         // types in result set. Just continue processing with these types
         // effect: dlls with external unused dependencies don't have to be shipped.
         Type[] ts;
+        var typeScanIncomplete = false;
         try
         {
-            ts = a.GetTypes();
+            ts = a.GetTypes() ?? [];
         }
         catch (ReflectionTypeLoadException e)
         {
-            Report.Begin("ReflectionTypeLoadException error in assembly {0}", a.GetName().Name);
-            Report.Line("Full assembly name is {0}.", a.FullName);
-            Report.Line("Exception is {0}", e);
-            Report.Begin("Loader exceptions are");
-            foreach (var x in e.LoaderExceptions)
-            {
-                Report.Line("{0}", x);
-            }
-            Report.End();
-            Report.End();
-            ts = e.Types.Where(t => t != null).ToArray();
+            diagnostics ??= new QueryDiagnostics();
+            diagnostics.Add(e);
+            typeScanIncomplete = true;
+            ts = e.Types?.Where(t => t != null).ToArray() ?? [];
+        }
+        catch (Exception e)
+        {
+            AddDiagnostic(ref diagnostics, DiagnosticKind.TypeEnumeration,
+                GetAssemblyNameSafe(a), e);
+            typeScanIncomplete = true;
+            ts = [];
         }
 
-        var result = createResult(ts).ToArray();
-
-
-        // whatever happens, don't halt everything just because caching fails
+        ScanResult<T> scan;
         try
         {
-            // for standalone deployments cacheFileNames cannot be retrieved robustly - we skip those
-            if (!string.IsNullOrEmpty(cacheFileName))
+            scan = createResult(ts, ref diagnostics);
+        }
+        catch (Exception e)
+        {
+            AddDiagnostic(ref diagnostics, DiagnosticKind.TypeEnumeration,
+                GetAssemblyNameSafe(a), e);
+            scan = new ScanResult<T>([], true);
+        }
+
+        var incomplete = typeScanIncomplete || scan.Incomplete;
+        if (incomplete)
+        {
+            TryDeleteCacheFile(cacheFileName, ref diagnostics);
+        }
+        else
+        {
+            // whatever happens, don't halt everything just because caching fails
+            try
             {
+                // for standalone deployments cacheFileNames cannot be retrieved robustly - we skip those
+                if (!string.IsNullOrEmpty(cacheFileName))
+                {
+                    var headerLine =
+                        new CacheFileHeader { Version = 1, TimeStampOfCachedFile = assemblyTimeStamp }
+                        .ToString()
+                        .IntoIEnumerable();
 
-                // write cache file
-                var headerLine =
-                    new CacheFileHeader { Version = 1, TimeStampOfCachedFile = assemblyTimeStamp }
-                    .ToString()
-                    .IntoIEnumerable();
-
-                File.WriteAllLines(cacheFileName, headerLine.Concat(encode(result)).ToArray());
+                    File.WriteAllLines(cacheFileName, headerLine.Concat(encode(scan.Items)).ToArray());
+                }
+            }
+            catch(Exception e)
+            {
+                AddDiagnostic(ref diagnostics, DiagnosticKind.CacheAccess, cacheFileName, e);
             }
         }
-        catch(Exception e)
-        {
-            Report.Warn("Could not write cache for {1}: {0}", e.Message, a.FullName);
-        }
 
-        return result;
+        ReportDiagnostics(a, discriminator, diagnostics);
+        return scan.Items;
+    }
+
+    private static void TryDeleteCacheFile(
+        string cacheFileName, ref QueryDiagnostics diagnostics
+    )
+    {
+        if (string.IsNullOrEmpty(cacheFileName) || !File.Exists(cacheFileName)) return;
+
+        try
+        {
+            File.Delete(cacheFileName);
+        }
+        catch (Exception e)
+        {
+            AddDiagnostic(ref diagnostics, DiagnosticKind.CacheAccess, cacheFileName, e);
+        }
     }
 }

--- a/src/Tests/Aardvark.Base.Tests/System/IntrospectionTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/System/IntrospectionTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 
 namespace Aardvark.Tests
 {
@@ -16,12 +17,12 @@ namespace Aardvark.Tests
         [Test]
         public void MethodAttributeCacheMissStoresEachDeclaringTypeOnce()
         {
-            WithFreshCache(() =>
+            WithFreshCache<MethodCacheTestAttribute>(() =>
             {
                 var miss = Query();
                 AssertExpectedMethods(miss);
 
-                var lines = File.ReadAllLines(GetSingleCacheFile());
+                var lines = File.ReadAllLines(GetSingleCacheFile<MethodCacheTestAttribute>());
                 Assert.That(lines[0], Does.StartWith("version 1 "));
 
                 var expectedTypes = miss
@@ -46,12 +47,12 @@ namespace Aardvark.Tests
         [Test]
         public void LegacyMethodAttributeCacheLinesAreDeduplicated()
         {
-            WithFreshCache(() =>
+            WithFreshCache<MethodCacheTestAttribute>(() =>
             {
                 var miss = Query();
                 AssertExpectedMethods(miss);
 
-                var cacheFile = GetSingleCacheFile();
+                var cacheFile = GetSingleCacheFile<MethodCacheTestAttribute>();
                 var lines = File.ReadAllLines(cacheFile);
                 Assert.AreEqual(3, lines.Length);
 
@@ -68,6 +69,149 @@ namespace Aardvark.Tests
                 var hit = Query();
                 AssertExpectedMethods(hit);
                 CollectionAssert.AreEqual(MethodKeys(miss), MethodKeys(hit));
+            });
+        }
+
+        [Test]
+        public void TypeAttributeFailuresPreservePartialResultsWithoutCaching()
+        {
+            WithFreshCache<RecoverableTypeAttribute>(() =>
+            {
+                RecoverableTypeAttribute.ThrowOnBad = true;
+                var (partial, report) = CaptureReport(() =>
+                    Introspection.GetAllTypesWithAttribute<RecoverableTypeAttribute>(s_assembly));
+
+                CollectionAssert.AreEqual(
+                    new[] { typeof(RecoverableTypeGoodFixture) },
+                    partial.Select(result => result.Item1).ToArray());
+                Assert.That(GetCacheFiles<RecoverableTypeAttribute>(), Is.Empty);
+                StringAssert.Contains("type attribute construction: 5 failure(s), 1 unique diagnostic(s)", report);
+                Assert.AreEqual(1, CountOccurrences(report, RecoverableTypeAttribute.FailureMessage));
+
+                RecoverableTypeAttribute.ThrowOnBad = false;
+                var recovered = Introspection.GetAllTypesWithAttribute<RecoverableTypeAttribute>(s_assembly);
+                Assert.AreEqual(6, recovered.Length);
+                Assert.That(GetCacheFiles<RecoverableTypeAttribute>(), Has.Length.EqualTo(1));
+
+                var hit = Introspection.GetAllTypesWithAttribute<RecoverableTypeAttribute>(s_assembly);
+                CollectionAssert.AreEqual(
+                    recovered.Select(result => result.Item1).ToArray(),
+                    hit.Select(result => result.Item1).ToArray());
+            }, () => RecoverableTypeAttribute.ThrowOnBad = false);
+        }
+
+        [Test]
+        public void MethodAttributeCacheFailuresRetryLiveAndRecover()
+        {
+            WithFreshCache<RecoverableMethodAttribute>(() =>
+            {
+                RecoverableMethodAttribute.ThrowOnBad = false;
+                var initial = Introspection.GetAllMethodsWithAttribute<RecoverableMethodAttribute>(s_assembly);
+                Assert.AreEqual(6, initial.Length);
+                Assert.That(GetCacheFiles<RecoverableMethodAttribute>(), Has.Length.EqualTo(1));
+
+                RecoverableMethodAttribute.ThrowOnBad = true;
+                var (partial, report) = CaptureReport(() =>
+                    Introspection.GetAllMethodsWithAttribute<RecoverableMethodAttribute>(s_assembly));
+
+                CollectionAssert.AreEqual(
+                    new[] { nameof(RecoverableMethodFixture.Good) },
+                    partial.Select(result => result.Item1.Name).ToArray());
+                StringAssert.Contains("Retrying incomplete cache query live", report);
+                StringAssert.Contains("method attribute construction: 10 failure(s), 1 unique diagnostic(s)", report);
+                Assert.AreEqual(1, CountOccurrences(report, RecoverableMethodAttribute.FailureMessage));
+                Assert.That(GetCacheFiles<RecoverableMethodAttribute>(), Is.Empty);
+
+                RecoverableMethodAttribute.ThrowOnBad = false;
+                var recovered = Introspection.GetAllMethodsWithAttribute<RecoverableMethodAttribute>(s_assembly);
+                Assert.AreEqual(6, recovered.Length);
+                Assert.That(GetCacheFiles<RecoverableMethodAttribute>(), Has.Length.EqualTo(1));
+
+                var hit = Introspection.GetAllMethodsWithAttribute<RecoverableMethodAttribute>(s_assembly);
+                CollectionAssert.AreEqual(MethodKeys(recovered), MethodKeys(hit));
+            }, () => RecoverableMethodAttribute.ThrowOnBad = false);
+        }
+
+        [Test]
+        public void ReflectionTypeLoadDiagnosticsAreBoundedAndRecoverable()
+        {
+            WithFreshCache<LoaderPartialAttribute>(() =>
+            {
+                var assembly = new ControllableAssembly(
+                    "IntrospectionLoaderFixture",
+                    new[] { typeof(LoaderPartialFixture) },
+                    new Exception[]
+                    {
+                        new FileNotFoundException("shared missing dependency"),
+                        new FileNotFoundException("shared missing dependency"),
+                        new FileNotFoundException("shared missing dependency"),
+                        new TypeLoadException("missing type one"),
+                        new TypeLoadException("missing type two"),
+                        new TypeLoadException("missing type three"),
+                        new TypeLoadException("missing type four"),
+                    });
+
+                assembly.ThrowTypeLoadException = true;
+                var (partial, report) = CaptureReport(() =>
+                    Introspection.GetAllTypesWithAttribute<LoaderPartialAttribute>(assembly));
+
+                CollectionAssert.AreEqual(
+                    new[] { typeof(LoaderPartialFixture) },
+                    partial.Select(result => result.Item1).ToArray());
+                Assert.That(GetCacheFiles<LoaderPartialAttribute>(), Is.Empty);
+                StringAssert.Contains("ReflectionTypeLoadException affected 1 assembly type scan(s)", report);
+                StringAssert.Contains("loader exceptions: 7 failure(s), 5 unique diagnostic(s)", report);
+                StringAssert.Contains("2 additional unique diagnostic(s) omitted", report);
+                Assert.AreEqual(1, CountOccurrences(report, "shared missing dependency"));
+                StringAssert.DoesNotContain("   at ", report);
+                Assert.LessOrEqual(report.Split('\n').Length, 12);
+
+                assembly.ThrowTypeLoadException = false;
+                var recovered = Introspection.GetAllTypesWithAttribute<LoaderPartialAttribute>(assembly);
+                Assert.AreEqual(1, recovered.Length);
+                Assert.That(GetCacheFiles<LoaderPartialAttribute>(), Has.Length.EqualTo(1));
+
+                var hit = Introspection.GetAllTypesWithAttribute<LoaderPartialAttribute>(assembly);
+                CollectionAssert.AreEqual(
+                    recovered.Select(result => result.Item1).ToArray(),
+                    hit.Select(result => result.Item1).ToArray());
+            });
+        }
+
+        [Test]
+        public void MethodEnumerationFailuresPreserveOtherTypesAndRecover()
+        {
+            WithFreshCache<MethodEnumerationAttribute>(() =>
+            {
+                var failingType = new RecoverableMethodsType(typeof(MethodEnumerationFailingFixture));
+                var assembly = new ControllableAssembly(
+                    "IntrospectionMethodEnumerationFixture",
+                    new Type[] { typeof(MethodEnumerationGoodFixture), failingType },
+                    Array.Empty<Exception>());
+
+                failingType.ThrowOnGetMethods = true;
+                var (partial, report) = CaptureReport(() =>
+                    Introspection.GetAllMethodsWithAttribute<MethodEnumerationAttribute>(assembly));
+
+                CollectionAssert.AreEqual(
+                    new[] { nameof(MethodEnumerationGoodFixture.Good) },
+                    partial.Select(result => result.Item1.Name).ToArray());
+                StringAssert.Contains("method enumeration: 1 failure(s), 1 unique diagnostic(s)", report);
+                Assert.That(GetCacheFiles<MethodEnumerationAttribute>(), Is.Empty);
+
+                failingType.ThrowOnGetMethods = false;
+                var recovered = Introspection.GetAllMethodsWithAttribute<MethodEnumerationAttribute>(assembly);
+                CollectionAssert.AreEquivalent(
+                    new[]
+                    {
+                        nameof(MethodEnumerationGoodFixture.Good),
+                        nameof(MethodEnumerationFailingFixture.Recovered),
+                    },
+                    recovered.Select(result => result.Item1.Name).ToArray());
+                Assert.That(GetCacheFiles<MethodEnumerationAttribute>(), Has.Length.EqualTo(1));
+
+                var hit = Introspection.GetAllMethodsWithAttribute<MethodEnumerationAttribute>(assembly);
+                CollectionAssert.AreEqual(MethodKeys(recovered), MethodKeys(hit));
             });
         }
 
@@ -88,45 +232,82 @@ namespace Aardvark.Tests
                 results.Select(result => result.Item1.Name).ToArray());
         }
 
-        private static string[] MethodKeys((MethodInfo, MethodCacheTestAttribute[])[] results)
+        private static string[] MethodKeys<TAttribute>((MethodInfo, TAttribute[])[] results)
             => results
                 .Select(result => $"{result.Item1.DeclaringType.AssemblyQualifiedName}|{result.Item1.MetadataToken}")
                 .ToArray();
 
-        private static void WithFreshCache(Action action)
+        private static void WithFreshCache<TAttribute>(Action action, Action cleanup = null)
         {
-            DeleteFixtureCacheFiles();
+            DeleteCacheFiles<TAttribute>();
             try
             {
                 action();
             }
             finally
             {
-                DeleteFixtureCacheFiles();
+                cleanup?.Invoke();
+                DeleteCacheFiles<TAttribute>();
             }
         }
 
-        private static string GetSingleCacheFile()
+        private static string GetSingleCacheFile<TAttribute>()
         {
-            var files = GetFixtureCacheFiles();
+            var files = GetCacheFiles<TAttribute>();
             Assert.AreEqual(1, files.Length);
             return files[0];
         }
 
-        private static string[] GetFixtureCacheFiles()
+        private static string[] GetCacheFiles<TAttribute>()
         {
             if (!Directory.Exists(Introspection.CacheDirectory)) return Array.Empty<string>();
 
-            var guid = typeof(MethodCacheTestAttribute).FullName.ToGuid();
+            var guid = typeof(TAttribute).FullName.ToGuid();
             return Directory.GetFiles(
                 Introspection.CacheDirectory,
                 $"*_{guid}.query",
                 SearchOption.TopDirectoryOnly);
         }
 
-        private static void DeleteFixtureCacheFiles()
+        private static void DeleteCacheFiles<TAttribute>()
         {
-            foreach (var file in GetFixtureCacheFiles()) File.Delete(file);
+            foreach (var file in GetCacheFiles<TAttribute>()) File.Delete(file);
+        }
+
+        private static (T Result, string Report) CaptureReport<T>(Func<T> action)
+        {
+            var previousRootTarget = Report.RootTarget;
+            var output = new StringBuilder();
+            var target = new TextLogTarget(
+                (threadIndex, type, level, message) => output.Append(message))
+            {
+                Verbosity = int.MaxValue,
+                LogCompleteLinesOnly = true,
+            };
+            target.PrefixFun = _ => "";
+
+            try
+            {
+                Report.RootTarget = target;
+                return (action(), output.ToString());
+            }
+            finally
+            {
+                target.Dispose();
+                Report.RootTarget = previousRootTarget;
+            }
+        }
+
+        private static int CountOccurrences(string text, string value)
+        {
+            var count = 0;
+            var offset = 0;
+            while ((offset = text.IndexOf(value, offset, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                offset += value.Length;
+            }
+            return count;
         }
 
         [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
@@ -154,6 +335,140 @@ namespace Aardvark.Tests
         {
             [MethodCacheTest("derived")]
             public void DerivedInstance() { }
+        }
+
+        [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+        private sealed class RecoverableTypeAttribute : Attribute
+        {
+            public const string FailureMessage = "recoverable type attribute failure";
+            public static bool ThrowOnBad;
+
+            public RecoverableTypeAttribute(string value)
+            {
+                if (ThrowOnBad && value == "bad")
+                    throw new InvalidOperationException(FailureMessage);
+            }
+        }
+
+        [RecoverableType("good")]
+        private sealed class RecoverableTypeGoodFixture { }
+
+        [RecoverableType("bad")]
+        private sealed class RecoverableTypeBadFixture1 { }
+
+        [RecoverableType("bad")]
+        private sealed class RecoverableTypeBadFixture2 { }
+
+        [RecoverableType("bad")]
+        private sealed class RecoverableTypeBadFixture3 { }
+
+        [RecoverableType("bad")]
+        private sealed class RecoverableTypeBadFixture4 { }
+
+        [RecoverableType("bad")]
+        private sealed class RecoverableTypeBadFixture5 { }
+
+        [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+        private sealed class RecoverableMethodAttribute : Attribute
+        {
+            public const string FailureMessage = "recoverable method attribute failure";
+            public static bool ThrowOnBad;
+
+            public RecoverableMethodAttribute(string value)
+            {
+                if (ThrowOnBad && value == "bad")
+                    throw new InvalidOperationException(FailureMessage);
+            }
+        }
+
+        private sealed class RecoverableMethodFixture
+        {
+            [RecoverableMethod("good")]
+            public void Good() { }
+
+            [RecoverableMethod("bad")]
+            public void Bad1() { }
+
+            [RecoverableMethod("bad")]
+            public void Bad2() { }
+
+            [RecoverableMethod("bad")]
+            public void Bad3() { }
+
+            [RecoverableMethod("bad")]
+            public void Bad4() { }
+
+            [RecoverableMethod("bad")]
+            public void Bad5() { }
+        }
+
+        [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+        private sealed class LoaderPartialAttribute : Attribute { }
+
+        [LoaderPartial]
+        private sealed class LoaderPartialFixture { }
+
+        [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+        private sealed class MethodEnumerationAttribute : Attribute { }
+
+        private sealed class MethodEnumerationGoodFixture
+        {
+            [MethodEnumeration]
+            public void Good() { }
+        }
+
+        private sealed class MethodEnumerationFailingFixture
+        {
+            [MethodEnumeration]
+            public void Recovered() { }
+        }
+
+        private sealed class RecoverableMethodsType : TypeDelegator
+        {
+            public bool ThrowOnGetMethods { get; set; }
+
+            public RecoverableMethodsType(Type delegatingType)
+                : base(delegatingType)
+            {
+            }
+
+            public override MethodInfo[] GetMethods(BindingFlags bindingAttr)
+            {
+                if (ThrowOnGetMethods)
+                    throw new InvalidOperationException("recoverable method enumeration failure");
+                return base.GetMethods(bindingAttr);
+            }
+        }
+
+        private sealed class ControllableAssembly : Assembly
+        {
+            private readonly AssemblyName m_name;
+            private readonly Type[] m_types;
+            private readonly Exception[] m_loaderExceptions;
+
+            public bool ThrowTypeLoadException { get; set; }
+
+            public ControllableAssembly(string name, Type[] types, Exception[] loaderExceptions)
+            {
+                m_name = new AssemblyName(name) { Version = new Version(1, 0, 0, 0) };
+                m_types = types;
+                m_loaderExceptions = loaderExceptions;
+            }
+
+            public override string FullName => m_name.FullName;
+            public override string Location => s_assembly.Location;
+
+            public override AssemblyName GetName(bool copiedName)
+                => new(m_name.FullName);
+
+            public override Type[] GetTypes()
+            {
+                if (!ThrowTypeLoadException) return m_types;
+
+                var partialTypes = new Type[m_types.Length + 1];
+                Array.Copy(m_types, partialTypes, m_types.Length);
+                throw new ReflectionTypeLoadException(partialTypes, m_loaderExceptions);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- retain successful introspection results while aggregating type-load, method-enumeration, and attribute-construction failures
- bound diagnostics to deduplicated per-query summaries instead of emitting exception stacks or per-member messages
- prevent incomplete live scans from writing query caches and retry incomplete cache decodes live so transient failures can recover
- document cache/recovery semantics and add deterministic failure, partial-result, and recovery coverage

## Validation

- focused Release introspection tests: 6 passed, 0 failed
- `./build.sh`: 0 warnings, 0 errors
- `./test.sh`: 1,895 passed, 31 existing skips, 0 failed
- `./check-docs.sh`: passed

## Performance

Matched Release BenchmarkDotNet runs against the pre-change implementation showed:

| Query | Before | After | Allocation |
| --- | ---: | ---: | ---: |
| type cache miss | 177.25 us | 160.60 us | 25.87 KB -> 20.29 KB |
| type cache hit | 77.20 us | 84.88 us | 13.62 KB -> 13.59 KB |
| method cache miss | 486.67 us | 490.16 us | 384.80 KB -> 384.73 KB |
| method cache hit | 82.21 us | 80.04 us | 15.13 KB -> 15.13 KB |

The cache-hit confidence intervals overlap; no clean-path throughput or allocation regression was observed. Temporary benchmark sources and artifacts were removed.

Fixes #79
